### PR TITLE
Fix deployment process

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -16,8 +16,13 @@ do
   case $1 in
   --method) method="${2}" ; shift;;
   --network) network="${2}" ; shift;;
+  # Truffle
   --reset) reset=true;;
   --skip-dry-run) skip_dry_run=true;;
+  # Custom deployment
+  --factory) factory="${2}" ; shift;;
+  --wone) wone="${2}" ; shift;;
+  --multicall) multicall="${2}" ; shift;;
   -h|--help) usage; exit 1;;
   (--) shift; break;;
   (-*) usage; exit 1;;
@@ -60,8 +65,24 @@ truffle_deployment() {
 }
 
 hmy_deployment() {
-  echo "Deploying using hmy - network: ${network}"
-  node tools/deployment/deploy.js --network $network
+  factory_argument=""
+  if [ ! -z "$factory" ]; then
+    factory_argument="--factory ${factory}"
+  fi
+
+  wone_argument=""
+  if [ ! -z "$wone" ]; then
+    wone_argument="--wone ${wone}"
+  fi
+
+  multicall_argument=""
+  if [ ! -z "$multicall" ]; then
+    multicall_argument="--multicall ${multicall}"
+  fi
+
+  echo "Deploying using hmy - arguments: --network $network $factory_argument $wone_argument $multicall_argument"
+
+  node tools/deployment/deploy.js --network $network $factory_argument $wone_argument $multicall_argument
 }
 
 deploy() {

--- a/tools/deployment/deploy.js
+++ b/tools/deployment/deploy.js
@@ -70,7 +70,7 @@ async function deploy() {
     const addr = deployed[contract];
     env += `export ${contract.toUpperCase()}=${addr}; `
   }
-  console.log(`\n    ${env}`);
+  console.log(`\n    export NETWORK=${argv.network}; ${env}`);
 }
 
 async function deployDependencies() {

--- a/tools/deployment/deploy.js
+++ b/tools/deployment/deploy.js
@@ -43,7 +43,7 @@ const { getAddress } = require('@harmony-js/crypto');
 
 // Vars
 const network = new Network(argv.network);
-network.hmy.wallet.addByPrivateKey(network.accounts.deployer.private_key)
+network.hmy.wallet.addByPrivateKey(network.privateKeys.deployer)
 
 const deployed = {};
 
@@ -109,8 +109,8 @@ async function deployContract(contractName, args) {
 
 async function performContractDeployment(abi, args) {
   let contract = network.hmy.contracts.createContract(abi)
-  contract.wallet.addByPrivateKey(network.accounts.deployer.private_key)
-  // contract.wallet.setSigner(network.network.accounts.deployer.private_key);
+  contract.wallet.addByPrivateKey(network.privateKeys.deployer)
+  // contract.wallet.setSigner(network.privateKeys.deployer);
   
   let options = {
     arguments: args

--- a/tools/deployment/deploy.js
+++ b/tools/deployment/deploy.js
@@ -86,7 +86,7 @@ async function deployDependencies() {
 }
 
 async function deployFactory() {
-  const addr = await performContractDeployment(v2Factory.abi, [network.hmy.wallet.signer.address]);
+  const addr = await performContractDeployment(v2Factory, [network.hmy.wallet.signer.address]);
   console.log(`    Deployed contract UniswapV2Factory: ${addr} (${getAddress(addr).bech32})`)
   
   return addr
@@ -102,18 +102,19 @@ async function deployWONE() {
 
 async function deployContract(contractName, args) {
   let contractJson = require(`../../build/contracts/${contractName}`)
-  const contractAddress = await performContractDeployment(contractJson.abi, args)
+  const contractAddress = await performContractDeployment(contractJson, args)
 
   return contractAddress
 }
 
-async function performContractDeployment(abi, args) {
-  let contract = network.hmy.contracts.createContract(abi)
+async function performContractDeployment(contractJson, args) {
+  let contract = network.hmy.contracts.createContract(contractJson.abi)
   contract.wallet.addByPrivateKey(network.privateKeys.deployer)
   // contract.wallet.setSigner(network.privateKeys.deployer);
   
   let options = {
-    arguments: args
+    arguments: args,
+    data: '0x' + contractJson.bytecode
   };
 
   let response = await contract.methods.contractConstructor(options).send(network.gasOptions())

--- a/tools/deployment/deploy.js
+++ b/tools/deployment/deploy.js
@@ -1,3 +1,7 @@
+const v2Factory = require('@harmony-swoop/core/build/contracts/UniswapV2Factory.json');
+
+require('dotenv').config()
+
 // Args
 const yargs = require('yargs');
 const argv = yargs
@@ -7,9 +11,31 @@ const argv = yargs
         type: 'string',
         default: 'testnet'
     })
+    .option('factory', {
+      alias: 'f',
+      description: 'The address of the UniswapV2Factory',
+      type: 'string',
+      default: process.env.UNISWAPV2FACTORY
+    })
+    .option('wone', {
+      alias: 'w',
+      description: 'The address of the WONE token contract',
+      type: 'string',
+      default: process.env.WONE
+    })
+    .option('multicall', {
+      alias: 'm',
+      description: 'The address of the Multicall contract',
+      type: 'string',
+      default: process.env.MULTICALL
+    })
     .help()
     .alias('help', 'h')
     .argv;
+
+var factoryAddress = argv.factory;
+var woneAddress = argv.wone;
+var multiCallAddress = argv.multicall;
 
 // Libs
 const Network = require('../network.js');
@@ -19,46 +45,74 @@ const { getAddress } = require('@harmony-js/crypto');
 const network = new Network(argv.network);
 network.hmy.wallet.addByPrivateKey(network.accounts.deployer.private_key)
 
-const contracts = {
-  // SafeMath: [],
-  // RouterEventEmitter: [],
-  // Multicall: [],
-  // Migrations: [],
-
-  // DeflatingHRC20: [10000000],
-
-  // IUniswapV2Callee: [],
-  // IUniswapV1Exchange: [],
-  // IUniswapV1Factory: [],
-  // IUniswapV2Factory: [],
-  // IUniswapV2Pair: [],
-  // IUniswapV2Router01: [],
-  // IUniswapV2Router02: [],
-  // IUniswapV2Migrator: [],
-
-  UniswapV2Router01: [network.accounts.deployer.address, process.env.WONE_ADDRESS],
-  UniswapV2Router02: [network.accounts.deployer.address, process.env.WONE_ADDRESS],
-  UniswapV2Migrator: [process.env.V1_FACTORY, process.env.ROUTER_1],
-  UniswapV2Library: [],
-  UniswapV2OracleLibrary: []
-}
+const deployed = {};
 
 async function deploy() {
+  await deployDependencies();
+  
+  const contracts = {
+    UniswapV2Router02: [factoryAddress, woneAddress],
+  }
+
+  if (multiCallAddress == null || multiCallAddress == '') {
+    contracts['Multicall'] = [];
+  }
+
   for (const contract in contracts) {
     const args = contracts[contract];
     const addr = await deployContract(contract, args);
+    deployed[contract] = addr;
     console.log(`    Deployed contract ${contract}: ${addr} (${getAddress(addr).bech32})`)
   }
+
+  var env = '';
+  for (const contract in deployed) {
+    const addr = deployed[contract];
+    env += `export ${contract.toUpperCase()}=${addr}; `
+  }
+  console.log(`\n    ${env}`);
+}
+
+async function deployDependencies() {
+  if (factoryAddress == null || factoryAddress == '') {
+    factoryAddress = await deployFactory()
+  }
+  deployed['UniswapV2Factory'] = factoryAddress;
+  
+  if (woneAddress == null || woneAddress == '') {
+    woneAddress = await deployWONE();
+  }
+  deployed['WONE'] = woneAddress;
+}
+
+async function deployFactory() {
+  const addr = await performContractDeployment(v2Factory.abi, [network.hmy.wallet.signer.address]);
+  console.log(`    Deployed contract UniswapV2Factory: ${addr} (${getAddress(addr).bech32})`)
+  
+  return addr
+}
+
+async function deployWONE() {
+  const contract = 'WONE';
+  const addr = await deployContract(contract, []);
+  console.log(`    Deployed contract ${contract}: ${addr} (${getAddress(addr).bech32})`)
+  
+  return addr
 }
 
 async function deployContract(contractName, args) {
   let contractJson = require(`../../build/contracts/${contractName}`)
-  // console.log(JSON.stringify(contractJson.abi))
-  let contract = network.hmy.contracts.createContract(contractJson.abi)
+  const contractAddress = await performContractDeployment(contractJson.abi, args)
+
+  return contractAddress
+}
+
+async function performContractDeployment(abi, args) {
+  let contract = network.hmy.contracts.createContract(abi)
   contract.wallet.addByPrivateKey(network.accounts.deployer.private_key)
   // contract.wallet.setSigner(network.network.accounts.deployer.private_key);
+  
   let options = {
-    data: '0x' + contractJson.bytecode,
     arguments: args
   };
 

--- a/tools/network.js
+++ b/tools/network.js
@@ -44,12 +44,10 @@ module.exports = class Network {
 
     this.accounts = {
       deployer: {
-        private_key: process.env[`${this.network.toUpperCase()}_PRIVATE_KEY`],
-        address: process.env[`${this.network.toUpperCase()}_ADDRESS`]
+        private_key: process.env[`${this.network.toUpperCase()}_PRIVATE_KEY`]
       },
       tester: {
-        private_key: process.env[`${this.network.toUpperCase()}_TEST_ACCOUNT_PRIVATE_KEY`],
-        address: process.env[`${this.network.toUpperCase()}_TEST_ACCOUNT_ADDRESS`]
+        private_key: process.env[`${this.network.toUpperCase()}_TEST_ACCOUNT_PRIVATE_KEY`]
       }
     }
   }

--- a/tools/network.js
+++ b/tools/network.js
@@ -1,83 +1,84 @@
-'use strict'
+'use strict';
 
-require('dotenv').config()
-const { Harmony } = require('@harmony-js/core')
-const { ChainID, ChainType } = require('@harmony-js/utils')
+require("dotenv").config();
+const { Harmony } = require("@harmony-js/core");
+const { ChainID, ChainType } = require("@harmony-js/utils");
 
 module.exports = class Network {
   constructor(network) {
-    this.hmy = null
-    this.accounts = { deployer: null, tester: null }
-    this.setNetwork(network)
-    this.gasPrice = process.env.GAS_PRICE
-    this.gasLimit = process.env.GAS_LIMIT
+    this.hmy = null;
+    this.privateKeys = {deployer: null, tester: null};
+    this.setNetwork(network);
+    this.gasPrice = process.env.GAS_PRICE;
+    this.gasLimit = process.env.GAS_LIMIT;
   }
 
   setNetwork(network) {
-    this.network = network.toLowerCase()
-    var url, chainType, chainId
+    this.network = network.toLowerCase();
+    var url, chainType, chainId;
 
     switch (this.network) {
       case 'testnet':
-        console.log('Using the testnet network...\n')
-        url = 'https://api.s0.b.hmny.io'
-        chainType = ChainType.Harmony
-        chainId = ChainID.HmyTestnet
-        break
+        console.log('Using the testnet network...\n');
+        url = "https://api.s0.b.hmny.io";
+        chainType = ChainType.Harmony;
+        chainId = ChainID.HmyTestnet;
+        break;
 
       case 'mainnet':
-        console.log('Using the mainnet network...\n')
-        url = 'https://api.s0.t.hmny.io'
-        chainType = ChainType.Harmony
-        chainId = ChainID.HmyMainnet
-        break
+        console.log('Using the mainnet network...\n');
+        url = "https://api.s0.t.hmny.io";
+        chainType = ChainType.Harmony;
+        chainId = ChainID.HmyMainnet;
+        break;
 
       default:
-        console.log('Please enter a valid network - testnet or mainnet.')
-        throw new Error('NetworkRequired')
+        console.log('Please enter a valid network - testnet or mainnet.');
+        throw new Error('NetworkRequired');
     }
 
-    this.hmy = new Harmony(url, {
-      chainType: chainType,
-      chainId: chainId
-    })
-
-    this.accounts = {
-      deployer: {
-        private_key: process.env[`${this.network.toUpperCase()}_PRIVATE_KEY`]
-      },
-      tester: {
-        private_key: process.env[`${this.network.toUpperCase()}_TEST_ACCOUNT_PRIVATE_KEY`]
+    this.hmy = new Harmony(
+      url,
+      {
+        chainType: chainType,
+        chainId: chainId,
       }
+    );
+
+    this.privateKeys = {
+      deployer: process.env[`${this.network.toUpperCase()}_PRIVATE_KEY`],
+      tester: process.env[`${this.network.toUpperCase()}_TEST_ACCOUNT_PRIVATE_KEY`]
     }
   }
 
   gasOptions() {
     return {
       gasPrice: this.gasPrice,
-      gasLimit: this.gasLimit
+      gasLimit: this.gasLimit,
     }
   }
 
   loadContract(path, address, privateKeyType) {
-    let contract = null
-    let privateKey = null
+    let contract = null;
+    let privateKey = null;
 
     switch (privateKeyType) {
-      case ('deployer', 'tester'):
-        this.accounts[privateKeyType].private_key
-        break
+      case 'deployer':
+      case 'tester':
+        privateKey = this.privateKeys[privateKeyType]
+        break;
 
       default:
-        privateKey = privateKeyType
+        privateKey = privateKeyType;
     }
 
     if (privateKey != null && privateKey != '') {
-      const contractJson = require(path)
-      contract = this.hmy.contracts.createContract(contractJson.abi, address)
-      contract.wallet.addByPrivateKey(privateKey)
+      const contractJson = require(path);
+      contract = this.hmy.contracts.createContract(contractJson.abi, address);
+      contract.wallet.addByPrivateKey(privateKey);
     }
 
-    return contract
+    return contract;
   }
-}
+
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -39,84 +39,48 @@
     ethers "^4.0.45"
     ganache-core "^2.10.2"
 
-"@harmony-js/account@0.1.46":
-  version "0.1.46"
-  resolved "https://registry.yarnpkg.com/@harmony-js/account/-/account-0.1.46.tgz#454ceab8739df8be39bde4fc8a787f9b20938dc4"
-  integrity sha512-b1hOUfBrg657z/cyjsUBde2RcncmP1YSCThT/B9symRBPCsiYRQbrtq4Ghj6VgljXvXy7qXP+/dr7kHf6trbig==
+"@harmony-js/account@0.1.54":
+  version "0.1.54"
+  resolved "https://registry.yarnpkg.com/@harmony-js/account/-/account-0.1.54.tgz#10d201334df146fbc3b3cd5e1e0c21403a1c2761"
+  integrity sha512-IZqrGhTw7k8yzoyBsx/J2AQuwq5jxGA4xhoekSFfHTvL3knYkBMFDRQPWEQ5mran10w2z0DQOuVbKQEVokBsOA==
   dependencies:
-    "@harmony-js/core" "0.1.46"
-    "@harmony-js/crypto" "^0.1.45"
-    "@harmony-js/network" "^0.1.45"
-    "@harmony-js/staking" "^0.1.45"
-    "@harmony-js/transaction" "^0.1.45"
-    "@harmony-js/utils" "^0.1.45"
+    "@harmony-js/core" "0.1.54"
+    "@harmony-js/crypto" "0.1.54"
+    "@harmony-js/network" "0.1.54"
+    "@harmony-js/staking" "0.1.54"
+    "@harmony-js/transaction" "0.1.54"
+    "@harmony-js/utils" "0.1.54"
 
-"@harmony-js/account@0.1.53":
-  version "0.1.53"
-  resolved "https://registry.yarnpkg.com/@harmony-js/account/-/account-0.1.53.tgz#8e82508514908ad27ae75d2fd3d86239ab184eaf"
-  integrity sha512-GqvTj/6hxT0+hACZiXzYb03rTPa8bW9/qW6lf3uysbSINFEftfjr3cv+hahGglI34Qxi3cYOJ6sPGveFGgmxGw==
+"@harmony-js/contract@0.1.54":
+  version "0.1.54"
+  resolved "https://registry.yarnpkg.com/@harmony-js/contract/-/contract-0.1.54.tgz#7b0accd637759596147d646835bb7c44a25714b6"
+  integrity sha512-RR5I3VznjrCCqqCl65r3lJcdevp/XYbaYe7CWq7JlAEI+5Pw768CseQ++9zEk/81o/0uIp1lq2ZYXKQH/PwonA==
   dependencies:
-    "@harmony-js/core" "0.1.53"
-    "@harmony-js/crypto" "0.1.48"
-    "@harmony-js/network" "0.1.51"
-    "@harmony-js/staking" "0.1.51"
-    "@harmony-js/transaction" "0.1.51"
-    "@harmony-js/utils" "0.1.48"
+    "@harmony-js/account" "0.1.54"
+    "@harmony-js/crypto" "0.1.54"
+    "@harmony-js/network" "0.1.54"
+    "@harmony-js/transaction" "0.1.54"
+    "@harmony-js/utils" "0.1.54"
 
-"@harmony-js/contract@0.1.46":
-  version "0.1.46"
-  resolved "https://registry.yarnpkg.com/@harmony-js/contract/-/contract-0.1.46.tgz#67bf08fb78f079ef7bc9f484e9679d2b2129d0e9"
-  integrity sha512-LTmNvLJiy5zLIKVg1/g56YZZhJvDfZ8p0reCym3W3Yk1g+cUhKBzOZZYQmY/4KYzcjs7EuZCDDReIDQB9lQWBw==
+"@harmony-js/core@0.1.54", "@harmony-js/core@^0.1.50":
+  version "0.1.54"
+  resolved "https://registry.yarnpkg.com/@harmony-js/core/-/core-0.1.54.tgz#742c67825da643bc04e5263c0a93e9bb368278e0"
+  integrity sha512-QZukWaVDYB3suIcL5lTGA71I7sSykIeZwbrcHx9GtWfaV0U/fh4x6BWC1a3bdwJHyT4rlsJeqqVhKMw9hrcfdQ==
   dependencies:
-    "@harmony-js/account" "0.1.46"
-    "@harmony-js/crypto" "^0.1.45"
-    "@harmony-js/network" "^0.1.45"
-    "@harmony-js/transaction" "^0.1.45"
-    "@harmony-js/utils" "^0.1.45"
+    "@harmony-js/account" "0.1.54"
+    "@harmony-js/contract" "0.1.54"
+    "@harmony-js/crypto" "0.1.54"
+    "@harmony-js/network" "0.1.54"
+    "@harmony-js/staking" "0.1.54"
+    "@harmony-js/transaction" "0.1.54"
+    "@harmony-js/utils" "0.1.54"
 
-"@harmony-js/contract@0.1.53":
-  version "0.1.53"
-  resolved "https://registry.yarnpkg.com/@harmony-js/contract/-/contract-0.1.53.tgz#3b4af0b28d87ddeda5bd405c81b2514c07696990"
-  integrity sha512-YAL5bc9lIAdr0ssTLMhf4Iqftlr8sX/ZjGbeEucXQ6wWnLhMYZab+8oxhPXuREeglTZXi8M9YZiSV06eMwIDiA==
+"@harmony-js/crypto@0.1.54":
+  version "0.1.54"
+  resolved "https://registry.yarnpkg.com/@harmony-js/crypto/-/crypto-0.1.54.tgz#73949bf851cc1830b91c13707f342b89c94be831"
+  integrity sha512-JfrHT84x7BN9alE+Oe3OJruUZrEE1ZjbaWCuRb2YuZbSRuHoS1h240eJ2jgoiOTUU7oS886Kwfai4IXB0mhTtA==
   dependencies:
-    "@harmony-js/account" "0.1.46"
-    "@harmony-js/crypto" "0.1.48"
-    "@harmony-js/network" "0.1.51"
-    "@harmony-js/transaction" "0.1.51"
-    "@harmony-js/utils" "0.1.48"
-
-"@harmony-js/core@0.1.46":
-  version "0.1.46"
-  resolved "https://registry.yarnpkg.com/@harmony-js/core/-/core-0.1.46.tgz#082cd6db3563574f1b21e070ef9b882551cfbaf0"
-  integrity sha512-OiQm0zkkhuqH3E+Jya2V872FV25CvRSeJHfG64lQO8h0x+mwYlRsTpO+EzvSCG44Z2sv3t6Ut3xJuOYwmVqDbA==
-  dependencies:
-    "@harmony-js/account" "0.1.46"
-    "@harmony-js/contract" "0.1.46"
-    "@harmony-js/crypto" "^0.1.45"
-    "@harmony-js/network" "^0.1.45"
-    "@harmony-js/staking" "^0.1.45"
-    "@harmony-js/transaction" "^0.1.45"
-    "@harmony-js/utils" "^0.1.45"
-
-"@harmony-js/core@0.1.53", "@harmony-js/core@^0.1.50":
-  version "0.1.53"
-  resolved "https://registry.yarnpkg.com/@harmony-js/core/-/core-0.1.53.tgz#b704ebd325211eb501365742a2b35ac02d05227a"
-  integrity sha512-uS472PtdIIfsJ8DUR/6MFDwWkTMoeEe+SIVFZKJLdXlXxLgDXItBeKE49xX7KP7MUSyzD9sVX3rbzTk3ibXJ1g==
-  dependencies:
-    "@harmony-js/account" "0.1.53"
-    "@harmony-js/contract" "0.1.53"
-    "@harmony-js/crypto" "0.1.48"
-    "@harmony-js/network" "0.1.51"
-    "@harmony-js/staking" "0.1.51"
-    "@harmony-js/transaction" "0.1.51"
-    "@harmony-js/utils" "0.1.48"
-
-"@harmony-js/crypto@0.1.48", "@harmony-js/crypto@^0.1.45":
-  version "0.1.48"
-  resolved "https://registry.yarnpkg.com/@harmony-js/crypto/-/crypto-0.1.48.tgz#c4bec23317296ddac604297b73c1c4ad290b06c9"
-  integrity sha512-DQNmt44nAeHjmdO2eTp7jopZ7HlXbEjPdyijZN933xlMpcLt7cEMtUtOtUUfIPoK5pVGP6MPuVfIV4bGgAuW3g==
-  dependencies:
-    "@harmony-js/utils" "0.1.48"
+    "@harmony-js/utils" "0.1.54"
     aes-js "^3.1.2"
     bip39 "^2.5.0"
     bn.js "^4.11.8"
@@ -128,40 +92,40 @@
     scrypt-shim "github:web3-js/scrypt-shim"
     uuid "^3.3.2"
 
-"@harmony-js/network@0.1.51", "@harmony-js/network@^0.1.45":
-  version "0.1.51"
-  resolved "https://registry.yarnpkg.com/@harmony-js/network/-/network-0.1.51.tgz#d14b1c5c195989c8c0be5da469b87b978c73c22f"
-  integrity sha512-wA26DtF5QynvceshF+loTWIevGNhkGWQsvxMlU3+tMgvdhbIbeOAYpdPLaDoxVp5Ri59FMRo7VMNXNDb+OCoHQ==
+"@harmony-js/network@0.1.54":
+  version "0.1.54"
+  resolved "https://registry.yarnpkg.com/@harmony-js/network/-/network-0.1.54.tgz#25b090e4572303bad3c26fdc75797952920d396c"
+  integrity sha512-ONw8JFVR7DMrsuwVf/OgTeafNTRAc9S4jsgWZg/L61gTDJNKuFtf/wq5wgcgxgVMeoQIkK17tm49qFCye//H7g==
   dependencies:
-    "@harmony-js/utils" "0.1.48"
+    "@harmony-js/utils" "0.1.54"
     cross-fetch "^3.0.2"
     mitt "^1.2.0"
     websocket "^1.0.28"
 
-"@harmony-js/staking@0.1.51", "@harmony-js/staking@^0.1.45":
-  version "0.1.51"
-  resolved "https://registry.yarnpkg.com/@harmony-js/staking/-/staking-0.1.51.tgz#58450affa7ce58d741fc9806fa1ff8c64be6ee3c"
-  integrity sha512-PHJ+n+UYwHY1mWraSDou037ux3FRlT40Vlph9+EiHx0hvHJSCffpDSeF6V4OPgNGTjCxkGiA2Nx+iC0CRkIpPw==
+"@harmony-js/staking@0.1.54":
+  version "0.1.54"
+  resolved "https://registry.yarnpkg.com/@harmony-js/staking/-/staking-0.1.54.tgz#3a66c71a465f55e5b58f15248b44e72156c1ed93"
+  integrity sha512-r3vWrqa9ttqww9tftUw3Trxvw2QN+fpBUfLa8Zschwsp6jlfPdKuJ+FFTKWYsvJ2xgwjJNzyPoMQ2Vo15ALyAA==
   dependencies:
-    "@harmony-js/crypto" "0.1.48"
-    "@harmony-js/network" "0.1.51"
-    "@harmony-js/transaction" "0.1.51"
-    "@harmony-js/utils" "0.1.48"
+    "@harmony-js/crypto" "0.1.54"
+    "@harmony-js/network" "0.1.54"
+    "@harmony-js/transaction" "0.1.54"
+    "@harmony-js/utils" "0.1.54"
     text-encoding "^0.7.0"
 
-"@harmony-js/transaction@0.1.51", "@harmony-js/transaction@^0.1.45":
-  version "0.1.51"
-  resolved "https://registry.yarnpkg.com/@harmony-js/transaction/-/transaction-0.1.51.tgz#a05ac05e065fe07e72c00f617607be78da8f734d"
-  integrity sha512-3hPzaw+rWVbQJlu4AnKJTNsdxGdnzm+J+plnMtVeEQRWHG97vJbXZAApfZa1/QoV3Of8FTF9jqkBdgV3+Aw83w==
+"@harmony-js/transaction@0.1.54":
+  version "0.1.54"
+  resolved "https://registry.yarnpkg.com/@harmony-js/transaction/-/transaction-0.1.54.tgz#6309d8944c78ebce9529a63f03ff8193d6a7bc6d"
+  integrity sha512-J9CofH9HlSk9YPCS32c+lo6aurhA93+T7xBFL+HnnpWiBwvmZBFm7xrrbaNkDkSM9r6+pYnOzv/O7kiS8tXVmg==
   dependencies:
-    "@harmony-js/crypto" "0.1.48"
-    "@harmony-js/network" "0.1.51"
-    "@harmony-js/utils" "0.1.48"
+    "@harmony-js/crypto" "0.1.54"
+    "@harmony-js/network" "0.1.54"
+    "@harmony-js/utils" "0.1.54"
 
-"@harmony-js/utils@0.1.48", "@harmony-js/utils@^0.1.45":
-  version "0.1.48"
-  resolved "https://registry.yarnpkg.com/@harmony-js/utils/-/utils-0.1.48.tgz#523ba15e5743a5376b63e90512563bf110d2acac"
-  integrity sha512-zY/MAQDTgsgEk7HzZs/cRjeu5i2lUBjz4BXh5EU2hbBMYxuzIzNijt4gZlUG8CBcjlpIss34a0i0o8d+xPG9Nw==
+"@harmony-js/utils@0.1.54":
+  version "0.1.54"
+  resolved "https://registry.yarnpkg.com/@harmony-js/utils/-/utils-0.1.54.tgz#008162d4b9206ad8ac404a990255333656c63f70"
+  integrity sha512-+LzQrcOoNqi+ehcElXQABHUXyJl9XXkLWUn9oghYLctwRuF4xHmsyzOa5cNLzAuxuK/j/VfPHT4jZ+banevZjw==
   dependencies:
     "@types/bn.js" "^4.11.3"
     bn.js "^4.11.8"
@@ -265,19 +229,19 @@
     form-data "^3.0.0"
 
 "@types/node@*":
-  version "14.6.4"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.6.4.tgz#a145cc0bb14ef9c4777361b7bbafa5cf8e3acb5a"
-  integrity sha512-Wk7nG1JSaMfMpoMJDKUsWYugliB2Vy55pdjLpmLixeyMi7HizW2I/9QoxsPCkXl3dO+ZOVqPumKaDUv5zJu2uQ==
+  version "14.10.2"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.10.2.tgz#9b47a2c8e4dabd4db73b57e750b24af689600514"
+  integrity sha512-IzMhbDYCpv26pC2wboJ4MMOa9GKtjplXfcAqrMeNJpUUwpM/2ATt2w1JPUXwS6spu856TvKZL2AOmeU2rAxskw==
 
 "@types/node@^10.12.18", "@types/node@^10.3.2":
-  version "10.17.29"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-10.17.29.tgz#263b7013f9f4afa53585b199f9a4255d9613b178"
-  integrity sha512-zLo9rjUeQ5+QVhOufDwrb3XKyso31fJBJnk9wUUQIBDExF/O4LryvpOfozfUaxgqifTnlt7FyqsAPXUq5yFZSA==
+  version "10.17.34"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-10.17.34.tgz#8f5ee42d5e816d551450f5729022828d3f3c7293"
+  integrity sha512-DlT8xondSSUixRxkdXQ3+dIZmCWkM6PX8kqIx1Zqp+FA/GmHJwqPixMeF89OirKVCFBh7U1m1I1Oj4gSrUW5oQ==
 
 "@types/node@^12.6.1":
-  version "12.12.55"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-12.12.55.tgz#0aa266441cb9e1fd3e415a8f619cb7d776667cdd"
-  integrity sha512-Vd6xQUVvPCTm7Nx1N7XHcpX6t047ltm7TgcsOr4gFHjeYgwZevo+V7I1lfzHnj5BT5frztZ42+RTG4MwYw63dw==
+  version "12.12.59"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-12.12.59.tgz#3a6154c24d4b5bd95bb1ce921ef805fb722f24cc"
+  integrity sha512-D2MISWfv2j17aFBAkMD3lQ97vYpXCkAJMJf0mx2eKHNkzXA6Vo9w7A7BWi9fH8sOH1zeFb7fIhOo22z0TtrSag==
 
 "@types/pbkdf2@^3.0.0":
   version "3.1.0"
@@ -359,9 +323,9 @@ aes-js@^3.1.1, aes-js@^3.1.2:
   integrity sha512-e5pEa2kBnBOgR4Y/p20pskXI74UEz7de8ZGVo58asOtvSVG5YAbJeELPZxOmt+Bnz3rX753YKhfIn4X4l1PPRQ==
 
 ajv@^6.12.3:
-  version "6.12.4"
-  resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.12.4.tgz#0614facc4522127fa713445c6bfd3ebd376e2234"
-  integrity sha512-eienB2c9qVQs2KWexhkrdMLVDoIQCz5KSeLxwg9Lzk4DOfBtIK9PQwwufcsn1jjGuf9WZmqPMbGxOzfcuphJCQ==
+  version "6.12.5"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.12.5.tgz#19b0e8bae8f476e5ba666300387775fb1a00a4da"
+  integrity sha512-lRF8RORchjpKG50/WFf8xmg7sgCLFiYNNnqdKflk63whMQcWR5ngGjiSXkL9bjxy6B2npOK2HSMN49jEBMSkag==
   dependencies:
     fast-deep-equal "^3.1.1"
     fast-json-stable-stringify "^2.0.0"
@@ -1556,9 +1520,9 @@ camelcase@^5.0.0:
   integrity sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==
 
 caniuse-lite@^1.0.30000844:
-  version "1.0.30001124"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001124.tgz#5d9998190258e11630d674fc50ea8e579ae0ced2"
-  integrity sha512-zQW8V3CdND7GHRH6rxm6s59Ww4g/qGWTheoboW9nfeMg7sUoopIfKCcNZUjwYRCOrvereh3kwDpZj4VLQ7zGtA==
+  version "1.0.30001131"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001131.tgz#afad8a28fc2b7a0d3ae9407e71085a0ead905d54"
+  integrity sha512-4QYi6Mal4MMfQMSqGIRPGbKIbZygeN83QsWq1ixpUwvtfgAZot5BrCKzGygvZaV+CnELdTwD0S4cqUNozq7/Cw==
 
 caseless@~0.12.0:
   version "0.12.0"
@@ -1891,11 +1855,11 @@ cross-fetch@^2.1.0, cross-fetch@^2.1.1:
     whatwg-fetch "2.0.4"
 
 cross-fetch@^3.0.2:
-  version "3.0.5"
-  resolved "https://registry.yarnpkg.com/cross-fetch/-/cross-fetch-3.0.5.tgz#2739d2981892e7ab488a7ad03b92df2816e03f4c"
-  integrity sha512-FFLcLtraisj5eteosnX1gf01qYDCOc4fDy0+euOt8Kn9YBY2NtXL/pCoYPavw24NIQkQqm5ZOLsGD5Zzj0gyew==
+  version "3.0.6"
+  resolved "https://registry.yarnpkg.com/cross-fetch/-/cross-fetch-3.0.6.tgz#3a4040bc8941e653e0e9cf17f29ebcd177d3365c"
+  integrity sha512-KBPUbqgFjzWlVcURG+Svp9TlhA5uliYtiNx/0r8nv0pdypeQCRJ9IaSIc3q/x3q8t3F75cHuwxVql1HFGHCNJQ==
   dependencies:
-    node-fetch "2.6.0"
+    node-fetch "2.6.1"
 
 crypto-browserify@3.12.0:
   version "3.12.0"
@@ -2215,9 +2179,9 @@ ee-first@1.1.1:
   integrity sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=
 
 electron-to-chromium@^1.3.47:
-  version "1.3.562"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.562.tgz#79c20277ee1c8d0173a22af00e38433b752bc70f"
-  integrity sha512-WhRe6liQ2q/w1MZc8mD8INkenHivuHdrr4r5EQHNomy3NJux+incP6M6lDMd0paShP3MD0WGe5R1TWmEClf+Bg==
+  version "1.3.570"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.570.tgz#3f5141cc39b4e3892a276b4889980dabf1d29c7f"
+  integrity sha512-Y6OCoVQgFQBP5py6A/06+yWxUZHDlNr/gNDGatjH8AZqXl8X0tE4LfjLJsXGz/JmWJz8a6K7bR1k+QzZ+k//fg==
 
 elliptic@6.3.3:
   version "6.3.3"
@@ -2303,6 +2267,24 @@ es-abstract@^1.17.0-next.1, es-abstract@^1.17.2, es-abstract@^1.17.5:
     is-callable "^1.2.0"
     is-regex "^1.1.0"
     object-inspect "^1.7.0"
+    object-keys "^1.1.1"
+    object.assign "^4.1.0"
+    string.prototype.trimend "^1.0.1"
+    string.prototype.trimstart "^1.0.1"
+
+es-abstract@^1.18.0-next.0:
+  version "1.18.0-next.0"
+  resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.18.0-next.0.tgz#b302834927e624d8e5837ed48224291f2c66e6fc"
+  integrity sha512-elZXTZXKn51hUBdJjSZGYRujuzilgXo8vSPQzjGYXLvSlGiCo8VO8ZGV3kjo9a0WNJJ57hENagwbtlRuHuzkcQ==
+  dependencies:
+    es-to-primitive "^1.2.1"
+    function-bind "^1.1.1"
+    has "^1.0.3"
+    has-symbols "^1.0.1"
+    is-callable "^1.2.0"
+    is-negative-zero "^2.0.0"
+    is-regex "^1.1.1"
+    object-inspect "^1.8.0"
     object-keys "^1.1.1"
     object.assign "^4.1.0"
     string.prototype.trimend "^1.0.1"
@@ -2708,9 +2690,9 @@ ethereumjs-util@^6.0.0, ethereumjs-util@^6.1.0, ethereumjs-util@^6.2.0:
     rlp "^2.2.3"
 
 ethereumjs-util@^7.0.2:
-  version "7.0.4"
-  resolved "https://registry.yarnpkg.com/ethereumjs-util/-/ethereumjs-util-7.0.4.tgz#f4b2022a91416bf421b35b0d5b81c21e8abd8b7f"
-  integrity sha512-isldtbCn9fdnhBPxedMNbFkNWVZ8ZdQvKRDSrdflame/AycAPKMer+vEpndpBxYIB3qxN6bd3Gh1YCQW9LDkCQ==
+  version "7.0.5"
+  resolved "https://registry.yarnpkg.com/ethereumjs-util/-/ethereumjs-util-7.0.5.tgz#bc6e178dedbccc4b188c9ae6ae38db1906884b7b"
+  integrity sha512-gLLZVXYUHR6pamO3h/+M1jzKz7qE20PKFyFKtq1PrIHA6wcLI96mDz96EMkkhXfrpk30rhpkw0iRnzxKhqaIdQ==
   dependencies:
     "@types/bn.js" "^4.11.3"
     bn.js "^5.1.2"
@@ -3227,9 +3209,9 @@ functional-red-black-tree@^1.0.1, functional-red-black-tree@~1.0.1:
   integrity sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=
 
 ganache-core@^2.10.2:
-  version "2.11.2"
-  resolved "https://registry.yarnpkg.com/ganache-core/-/ganache-core-2.11.2.tgz#821a8e7beaa65b32e408ccae2e2ec49194c4e378"
-  integrity sha512-yZSMdR2xtqG2IdApeB6OywtMxwcHMp6Y5TUBwPyKe5/GripP8xnEpSKBluhxoyqEotg+Z2S8mjIXJyAm+NnMGw==
+  version "2.11.3"
+  resolved "https://registry.yarnpkg.com/ganache-core/-/ganache-core-2.11.3.tgz#c59e6c34b03279bffd32f4694ec8ed6f5f1d76a8"
+  integrity sha512-SsFJUnyiZI+jW3I43XluXi3TvJC3Ke6vZkvN6NjbWpXvi6dOrmafkyq9Rq07+Qrri6BLGKWoZcG8HfH6ietuqg==
   dependencies:
     abstract-leveldown "3.0.0"
     async "2.6.2"
@@ -3829,9 +3811,9 @@ is-buffer@~2.0.3:
   integrity sha512-Kq1rokWXOPXWuaMAqZiJW4XxsmD9zGx9q4aePabbn3qCRGedtH7Cm+zV8WETitMfu1wdh+Rvd6w5egwSngUX2A==
 
 is-callable@^1.1.3, is-callable@^1.1.4, is-callable@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/is-callable/-/is-callable-1.2.0.tgz#83336560b54a38e35e3a2df7afd0454d691468bb"
-  integrity sha512-pyVD9AaGLxtg6srb2Ng6ynWJqkHU9bEM087AKck0w8QwDarTfNcpIYoU8x8Hv2Icm8u6kFJM18Dag8lyqGkviw==
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/is-callable/-/is-callable-1.2.1.tgz#4d1e21a4f437509d25ce55f8184350771421c96d"
+  integrity sha512-wliAfSzx6V+6WfMOmus1xy0XvSgf/dlStkvTfq7F0g4bOIW0PSUbnyse3NhDwdyYS1ozfUtAAySqTws3z9Eqgg==
 
 is-data-descriptor@^0.1.4:
   version "0.1.4"
@@ -3943,6 +3925,11 @@ is-negated-glob@^1.0.0:
   resolved "https://registry.yarnpkg.com/is-negated-glob/-/is-negated-glob-1.0.0.tgz#6910bca5da8c95e784b5751b976cf5a10fee36d2"
   integrity sha1-aRC8pdqMleeEtXUbl2z1oQ/uNtI=
 
+is-negative-zero@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/is-negative-zero/-/is-negative-zero-2.0.0.tgz#9553b121b0fac28869da9ed459e20c7543788461"
+  integrity sha1-lVOxIbD6wohp2p7UWeIMdUN4hGE=
+
 is-number@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/is-number/-/is-number-3.0.0.tgz#24fd6201a4782cf50561c810276afc7d12d71195"
@@ -3972,7 +3959,7 @@ is-plain-object@^2.0.1, is-plain-object@^2.0.3, is-plain-object@^2.0.4:
   dependencies:
     isobject "^3.0.1"
 
-is-regex@^1.0.4, is-regex@^1.1.0:
+is-regex@^1.0.4, is-regex@^1.1.0, is-regex@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/is-regex/-/is-regex-1.1.1.tgz#c6f98aacc546f6cec5468a07b7b153ab564a57b9"
   integrity sha512-1+QkEcxiLlB7VEyFtyBg94e08OAsvq7FUBgApTq/w2ymCLyKJgDPsybBENVtA7XCQEgEXxKPonG+mvYRxh/LIg==
@@ -4891,10 +4878,10 @@ node-fetch@2.1.2:
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.1.2.tgz#ab884e8e7e57e38a944753cec706f788d1768bb5"
   integrity sha1-q4hOjn5X44qUR1POxwb3iNF2i7U=
 
-node-fetch@2.6.0, node-fetch@^2.6.0:
-  version "2.6.0"
-  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.0.tgz#e633456386d4aa55863f676a7ab0daa8fdecb0fd"
-  integrity sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA==
+node-fetch@2.6.1, node-fetch@^2.6.0:
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.1.tgz#045bd323631f76ed2e2b55573394416b639a0052"
+  integrity sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==
 
 node-fetch@~1.7.1:
   version "1.7.3"
@@ -4980,7 +4967,7 @@ object-copy@^0.1.0:
     define-property "^0.2.5"
     kind-of "^3.0.3"
 
-object-inspect@^1.7.0:
+object-inspect@^1.7.0, object-inspect@^1.8.0:
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.8.0.tgz#df807e5ecf53a609cc6bfe93eac3cc7be5b3a9d0"
   integrity sha512-jLdtEOB112fORuypAyl/50VRVIBIdVQOSUUGQHzJ4xBSbit81zRarz7GThkEFZy1RceYrWYcPcBFPQwHyAc1gA==
@@ -5015,7 +5002,7 @@ object-visit@^1.0.0:
   dependencies:
     isobject "^3.0.0"
 
-object.assign@4.1.0, object.assign@^4.0.4, object.assign@^4.1.0:
+object.assign@4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/object.assign/-/object.assign-4.1.0.tgz#968bf1100d7956bb3ca086f006f846b3bc4008da"
   integrity sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==
@@ -5024,6 +5011,16 @@ object.assign@4.1.0, object.assign@^4.0.4, object.assign@^4.1.0:
     function-bind "^1.1.1"
     has-symbols "^1.0.0"
     object-keys "^1.0.11"
+
+object.assign@^4.0.4, object.assign@^4.1.0:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/object.assign/-/object.assign-4.1.1.tgz#303867a666cdd41936ecdedfb1f8f3e32a478cdd"
+  integrity sha512-VT/cxmx5yaoHSOTSyrCygIDFco+RsibY2NM0a4RdEeY/4KgqezwFtK1yr3U67xYhqJSlASm2pKhLVzPj2lr4bA==
+  dependencies:
+    define-properties "^1.1.3"
+    es-abstract "^1.18.0-next.0"
+    has-symbols "^1.0.1"
+    object-keys "^1.1.1"
 
 object.defaults@^1.0.0, object.defaults@^1.1.0:
   version "1.1.0"
@@ -6326,13 +6323,12 @@ string-width@^3.0.0, string-width@^3.1.0:
     strip-ansi "^5.1.0"
 
 string.prototype.trim@~1.2.1:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/string.prototype.trim/-/string.prototype.trim-1.2.1.tgz#141233dff32c82bfad80684d7e5f0869ee0fb782"
-  integrity sha512-MjGFEeqixw47dAMFMtgUro/I0+wNqZB5GKXGt1fFr24u3TzDXCPu7J9Buppzoe3r/LqkSDLDDJzE15RGWDGAVw==
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/string.prototype.trim/-/string.prototype.trim-1.2.2.tgz#f538d0bacd98fc4297f0bef645226d5aaebf59f3"
+  integrity sha512-b5yrbl3BXIjHau9Prk7U0RRYcUYdN4wGSVaqoBQS50CCE3KBuYU0TYRNPFCP7aVoNMX87HKThdMRVIP3giclKg==
   dependencies:
     define-properties "^1.1.3"
-    es-abstract "^1.17.0-next.1"
-    function-bind "^1.1.1"
+    es-abstract "^1.18.0-next.0"
 
 string.prototype.trimend@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
This PR does the following:
- Removes unnecessary contracts from the deployment process - we don't need to deploy libraries, they'll automatically get included in the actual compiled smart contract that inherit from the libraries.
- Removes all deployed Uniswap contracts except `UniswapV2Router02.sol` - `UniswapV2Migrator.sol` is for migrating Uniswap V1 -> V2 (we don't need this), `UniswapV2Router01.sol` is a old & buggy version of the router and it shouldn't be used: https://uniswap.org/docs/v2/smart-contracts/router01/
- Updates the deployment script to automatically deploy the dependencies for `UniswapV2Router02.sol` (`UniswapV2Factory.sol` from swoop-core and `WONE` from swoop-periphery) when not specifying an existing factory address to use (using `--factory FACTORY_ADDRESS`) or an existing WONE contract address to use (using `--wone WONE_ADDRESS`)
- Correctly deploys the `UniswapV2Router02.sol` by supplying the address of a deployed `UniswapV2Factory.sol` contract. Previously the deployment just deployed the router contract with the address for the deploying user's wallet as the constructor argument - this is obviously not correct since the deployer's address is not a `UniswapV2Factory.sol` smart contract address.
- Deploys the Multicall contract unless specified with `--multicall MULTICALL_ADDRESS`